### PR TITLE
Add definitions for hidden and colorlist themebuilder variables

### DIFF
--- a/lib/schemas/css-color.json
+++ b/lib/schemas/css-color.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/css-color.json",
     "title": "Schema definition for CSS color",
 

--- a/lib/schemas/css-number.json
+++ b/lib/schemas/css-number.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/css-number.json",
     "title": "Schema definition for CSS number",
 

--- a/lib/schemas/css-unit.json
+++ b/lib/schemas/css-unit.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/css-unit.json",
     "title": "Schema definition for CSS unit",
 

--- a/lib/schemas/kendo-component.json
+++ b/lib/schemas/kendo-component.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/kendo-component.json",
     "title": "Schema for valid kendo component names",
 

--- a/lib/schemas/sass-variable.json
+++ b/lib/schemas/sass-variable.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/sass-variable.json",
     "title": "Sass schemas",
 

--- a/lib/schemas/themebuilder-swatch.json
+++ b/lib/schemas/themebuilder-swatch.json
@@ -85,7 +85,9 @@
                     "type": "string"
                 },
                 "type": {
-                    "$ref": "#/$defs/sass-variable-type"
+                    "description": "Variable type. One of color, number, boolean or hidden.",
+                    "markdownDescription": "Variable type. One of `color`, `number`, `boolean` or `hidden`.",
+                    "$ref": "#/$defs/variable-type"
                 },
                 "value": {}
             },
@@ -173,6 +175,19 @@
                             }
                         }
                     }
+                }
+            ]
+        },
+
+
+        "variable-type": {
+            "oneOf": [
+                {
+                    "$ref": "#/$defs/sass-variable-type"
+                },
+                {
+                    "type": "string",
+                    "const": "hidden"
                 }
             ]
         }

--- a/lib/schemas/themebuilder-swatch.json
+++ b/lib/schemas/themebuilder-swatch.json
@@ -28,7 +28,8 @@
             "items": {
                 "$ref": "#/$defs/css-color"
             },
-            "minimum": 2
+            "minItems": 2,
+            "maxItems": 8
         },
         "components": {
             "description": "Components to include in the compiled theme. Leave empty for all.",

--- a/lib/schemas/themebuilder-swatch.json
+++ b/lib/schemas/themebuilder-swatch.json
@@ -89,7 +89,8 @@
                     "markdownDescription": "Variable type. One of `color`, `number`, `boolean` or `hidden`.",
                     "$ref": "#/$defs/variable-type"
                 },
-                "value": {}
+                "value": {},
+                "enum": {}
             },
             "additionalProperties": false,
             "required": [ "name", "type", "value" ],
@@ -136,6 +137,32 @@
                 {
                     "if": {
                         "properties": {
+                            "type": { "const": "colorlist" },
+                            "required": [ "type" ]
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "value": {
+                                "description": "A specific color from discreet color list.",
+                                "markdownDescription": "A specific color from discreet color list.",
+                                "type": [
+                                    "string",
+                                    "null"
+                                ]
+                            },
+                            "enum": {
+                                "type": "array",
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
                             "type": { "const": "number" },
                             "required": [ "type" ]
                         }
@@ -167,11 +194,13 @@
                     "then": {
                         "properties": {
                             "value": {
+                                "description": "true or false",
+                                "markdownDescription": "`true` or `false`",
                                 "enum": [
                                     true,
-                                    false
-                                ],
-                                "description": "true or false"
+                                    false,
+                                    null
+                                ]
                             }
                         }
                     }
@@ -188,6 +217,10 @@
                 {
                     "type": "string",
                     "const": "hidden"
+                },
+                {
+                    "type": "string",
+                    "const": "colorlist"
                 }
             ]
         }

--- a/lib/schemas/themebuilder-swatch.json
+++ b/lib/schemas/themebuilder-swatch.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$schema": "http://json-schema.org/draft-07/schema",
     "$id": "kendo-cli://schemas/themebuilder-swatch.json",
     "title": "Themebuilder Swatch Definition",
 

--- a/test/schemas/themebuilder-swatch-primer.json
+++ b/test/schemas/themebuilder-swatch-primer.json
@@ -30,7 +30,7 @@
             "variables": {
                 "primary": {
                     "name": "Primary",
-                    "type": "color",
+                    "type": "hidden",
                     "value": "#ff6358"
                 },
                 "info": {

--- a/test/schemas/themebuilder-swatch-primer.json
+++ b/test/schemas/themebuilder-swatch-primer.json
@@ -21,6 +21,31 @@
                 "border-radius": {
                     "name": "Border radius",
                     "type": "number",
+                    "value": 0
+                },
+                "not-border-radius": {
+                    "name": "Border radius",
+                    "type": "number",
+                    "value": "0"
+                },
+                "yet-another-border-radius": {
+                    "name": "Border radius",
+                    "type": "number",
+                    "value": null
+                },
+                "not-another-border-radius": {
+                    "name": "Border radius",
+                    "type": "number",
+                    "value": "0.01px"
+                },
+                "enable-border-radius": {
+                    "name": "Border radius",
+                    "type": "boolean",
+                    "value": true
+                },
+                "disable-border-radius": {
+                    "name": "Border radius",
+                    "type": "boolean",
                     "value": null
                 }
             }
@@ -30,8 +55,28 @@
             "variables": {
                 "primary": {
                     "name": "Primary",
-                    "type": "hidden",
-                    "value": "#ff6358"
+                    "type": "colorlist",
+                    "value": null,
+                    "enum": [
+                        "red",
+                        "pink",
+                        "purple",
+                        "deepPurple",
+                        "indigo",
+                        "blue",
+                        "lightBlue",
+                        "cyan",
+                        "teal",
+                        "green",
+                        "lime",
+                        "yellow",
+                        "amber",
+                        "orange",
+                        "deepOrange",
+                        "brown",
+                        "gray",
+                        "blueGray"
+                    ]
                 },
                 "info": {
                     "name": "Info",


### PR DESCRIPTION
Misc:
* use `draft-07` schema to enable VScode tooling
* set `minItems` and `maxItems` for previewColors array