### PR TITLE
Add version field for swatches in checma definition

### DIFF
--- a/lib/schemas/kendo-swatch.json
+++ b/lib/schemas/kendo-swatch.json
@@ -27,6 +27,11 @@
                 "@telerik/webui-theme-silk"
             ]
         },
+        "version": {
+            "description": "Version of the theme to compile against. Note: this is recommended version.",
+            "markdownDescription": "Version of the theme to compile against.\n\nNote: this is **recommended** version.",
+            "type": "string"
+        },
         "product": {
             "description": "Product for which the theme is for. Either kendo or webui.",
             "type": "string",


### PR DESCRIPTION
Rationale:

The version field will allows us to specify recommended (sort of) version for each swatch. The main purpose is to use the version to facilitate migration from one version to another.

As a side note, it will make it easier for customers to know which version their swatch is currently using.

cc @rkirilov 