### PR TITLE
Pass either string of file option for sass-embedded

### DIFF
--- a/src/build/sass-build.js
+++ b/src/build/sass-build.js
@@ -75,7 +75,9 @@ function sassCompile( options ) {
     }
 
     try {
-        rawResult = sassCompiler.renderSync({ file, data, ...sassOptions });
+        rawResult = data !== undefined
+            ? sassCompiler.renderSync({ data, ...sassOptions })
+            : sassCompiler.renderSync({ file, ...sassOptions });
         result = rawResult.css.toString('utf-8');
 
         if ( typeof postcss === 'function' && postcssPlugins.length > 0 ) {


### PR DESCRIPTION
When passing both `file` and `data` in sass-embedded, the latter takes precedence and the file option is ignored, hence we get an empty file.