### PR TITLE
chore: update ci actions and node version

### DIFF
--- a/.github/workflows/ci_unit.yml
+++ b/.github/workflows/ci_unit.yml
@@ -18,12 +18,12 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Install
         run: npm ci --ignore-scripts

--- a/.github/workflows/merge_develop.yml
+++ b/.github/workflows/merge_develop.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           token: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release_stable.yml
+++ b/.github/workflows/release_stable.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
 
       - name: Checkout branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
           fetch-depth: '0'
@@ -33,9 +33,9 @@ jobs:
           git merge --ff-only --quiet origin/develop
 
       - name: Setup node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 18.x
 
       - name: Install
         run: npm ci --ignore-scripts


### PR DESCRIPTION
In this PR:

- Update actions to @v3
- Update node to v18 as [semantic-release 20.x requires it as a minimum](https://github.com/semantic-release/semantic-release/releases/tag/v20.0.0).